### PR TITLE
Charset matcher

### DIFF
--- a/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/CharsetCheck.java
+++ b/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/CharsetCheck.java
@@ -33,10 +33,10 @@ public class CharsetCheck extends Filter {
     static {
         Map<String, String> map = new HashMap<String, String>();
         map.put("latin", "\\p{InBasic_Latin}|\\p{InLatin-1_Supplement}|\\p{InLatin_Extended-A}|\\p{InLatin_Extended-B}|\\p{InLatin_Extended_Additional}");
-        map.put("greek", "\\p{InGreek_and_Coptic}|\\p{InGreek_Extended}");
+        map.put("greek", "\\p{InGreek}|\\p{InGreek_Extended}");
         map.put("cyrillic", "\\p{InCyrillic}|\\p{InCyrillic_Supplementary}");
         map.put("hebrew", "\\p{InHebrew}");
-        map.put("arabic", "\\p{InArabic}|\\p{InArabic_Presentation_Forms-A}|\\p{InArabic_Presentation_Forms-B}");
+        map.put("arabic", "\\p{InArabic}");
         CHARSETS = Collections.unmodifiableMap(map);
     }
 

--- a/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/CharsetCheck.java
+++ b/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/CharsetCheck.java
@@ -83,7 +83,7 @@ public class CharsetCheck extends Filter {
                 if(!input.source.contains(matched)) {
                     if(verbose) {
                         out = true;
-                        System.err.print("Target sentence " + input.target + " contains non-native script: \"" + matched + "\"");
+                        System.err.println("Target sentence " + input.target + " contains non-native script: \"" + matched + "\"");
                     } else {
                         return true;
                     }

--- a/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/CharsetCheck.java
+++ b/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/CharsetCheck.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright © 2017 Jim O'Regan
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package ie.tcd.slscs.itut.duckegg.bitext;
+
+import java.util.*;
+import java.util.regex.Pattern;
+
+public class CharsetCheck extends Filter {
+    private static final Map<String, String> CHARSETS;
+    static {
+        Map<String, String> map = new HashMap<String, String>();
+        map.put("latin", "\\p{InBasic_Latin}|\\p{InLatin-1_Supplement}|\\p{InLatin_Extended-A}|\\p{InLatin_Extended-B}|\\p{InLatin_Extended_Additional}");
+        map.put("greek", "\\p{InGreek_and_Coptic}|\\p{InGreek_Extended}");
+        map.put("cyrillic", "\\p{InCyrillic}|\\p{InCyrillic_Supplementary}");
+        map.put("hebrew", "\\p{InHebrew}");
+        map.put("arabic", "\\p{InArabic}|\\p{InArabic_Presentation_Forms-A}|\\p{InArabic_Presentation_Forms-B}");
+        CHARSETS = Collections.unmodifiableMap(map);
+    }
+
+    public static Pattern getPattern(String s) {
+        return Pattern.compile("((?:" + CHARSETS.get(s) + ")+)");
+    }
+    public static List<Pattern> getPatterns(String src, String trg) {
+        List<Pattern> out = new ArrayList<Pattern>();
+        for(String s : CHARSETS.keySet()) {
+            if(!s.equals(src) && !s.equals(trg)) {
+                out.add(getPattern(s));
+            }
+        }
+        return out;
+    }
+
+    @Override
+    public boolean needsLanguageProperties() {
+        return true;
+    }
+
+    @Override
+    public boolean match(SLTLPair input) {
+        List<Pattern> pats = getPatterns(srcProps.script, trgProps.script);
+        boolean out = false;
+        for(Pattern p : pats) {
+
+        }
+
+        return out;
+    }
+}

--- a/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/CharsetCheck.java
+++ b/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/CharsetCheck.java
@@ -25,6 +25,7 @@
 package ie.tcd.slscs.itut.duckegg.bitext;
 
 import java.util.*;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class CharsetCheck extends Filter {
@@ -61,8 +62,33 @@ public class CharsetCheck extends Filter {
     public boolean match(SLTLPair input) {
         List<Pattern> pats = getPatterns(srcProps.script, trgProps.script);
         boolean out = false;
+        boolean verbose = true;
         for(Pattern p : pats) {
+            Matcher srcm = p.matcher(input.source);
+            Matcher trgm = p.matcher(input.target);
 
+            while(srcm.find()) {
+                String matched = input.source.substring(srcm.start(), srcm.end());
+                if(!input.target.contains(matched)) {
+                    if(verbose) {
+                        out = true;
+                        System.err.print("Source sentence " + input.source + " contains non-native script: \"" + matched + "\"");
+                    } else {
+                        return true;
+                    }
+                }
+            }
+            while(trgm.find()) {
+                String matched = input.target.substring(trgm.start(), trgm.end());
+                if(!input.source.contains(matched)) {
+                    if(verbose) {
+                        out = true;
+                        System.err.print("Target sentence " + input.target + " contains non-native script: \"" + matched + "\"");
+                    } else {
+                        return true;
+                    }
+                }
+            }
         }
 
         return out;

--- a/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/CharsetCheck.java
+++ b/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/CharsetCheck.java
@@ -72,7 +72,7 @@ public class CharsetCheck extends Filter {
                 if(!input.target.contains(matched)) {
                     if(verbose) {
                         out = true;
-                        System.err.print("Source sentence " + input.source + " contains non-native script: \"" + matched + "\"");
+                        System.err.println("Source sentence " + input.source + " contains non-native script: \"" + matched + "\"");
                     } else {
                         return true;
                     }

--- a/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/CharsetCheck.java
+++ b/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/CharsetCheck.java
@@ -62,7 +62,6 @@ public class CharsetCheck extends Filter {
     public boolean match(SLTLPair input) {
         List<Pattern> pats = getPatterns(srcProps.script, trgProps.script);
         boolean out = false;
-        boolean verbose = true;
         for(Pattern p : pats) {
             Matcher srcm = p.matcher(input.source);
             Matcher trgm = p.matcher(input.target);

--- a/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/Filter.java
+++ b/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/Filter.java
@@ -24,17 +24,11 @@
 
 package ie.tcd.slscs.itut.duckegg.bitext;
 
-import java.util.List;
-
-public abstract class Rule extends RuleBase {
+public abstract class Filter extends RuleBase {
     /**
-     * Corrects the input matched by the rule
+     * Checks if the input matches the filter
      * @param input The pair to be processed
-     * @return A new SLTLPair with corrections applied
+     * @return true if there is a match
      */
-    public abstract SLTLPair replace(SLTLPair input) throws Exception;
-    public boolean replacement = false;
-    public boolean hadReplacement() {
-        return replacement;
-    }
+    public abstract boolean match(SLTLPair input);
 }

--- a/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/LanguageProperties.java
+++ b/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/LanguageProperties.java
@@ -24,17 +24,7 @@
 
 package ie.tcd.slscs.itut.duckegg.bitext;
 
-import java.util.List;
-
-public abstract class Rule extends RuleBase {
-    /**
-     * Corrects the input matched by the rule
-     * @param input The pair to be processed
-     * @return A new SLTLPair with corrections applied
-     */
-    public abstract SLTLPair replace(SLTLPair input) throws Exception;
-    public boolean replacement = false;
-    public boolean hadReplacement() {
-        return replacement;
-    }
+public class LanguageProperties {
+    String name;
+    String script;
 }

--- a/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/Opus.java
+++ b/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/Opus.java
@@ -55,6 +55,6 @@ public class Opus {
             }
         }
 
-        Text.read(base + "-filt", sl, tl);
+        Text.write(out, base + "-filt", sl, tl);
     }
 }

--- a/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/Opus.java
+++ b/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/Opus.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright © 2017 Jim O'Regan
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package ie.tcd.slscs.itut.duckegg.bitext;
+
+import ie.tcd.slscs.itut.duckegg.format.opus.Text;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Opus {
+    public static void main(String[] args) throws Exception {
+        /*
+        if(args.length != 3) {
+            throw new Exception("Usage: basename source-language target-language");
+        }
+        String base = args[0];
+        String sl = args[1];
+        String tl = args[2];*/
+        String base = "EUbookshop.en-ga";
+        String sl = "en";
+        String tl = "ga";
+        LanguageProperties enlp = new LanguageProperties("english", "latin");
+        LanguageProperties galp = new LanguageProperties("irish", "latin");
+
+        List<SLTLPair> orig = Text.read(base, sl, tl);
+        List<SLTLPair> out = new ArrayList<SLTLPair>();
+
+        CharsetCheck ck = new CharsetCheck();
+        ck.setLanguageProperties(enlp, galp);
+
+        for (SLTLPair sent : orig) {
+            if(!ck.match(sent)) {
+                out.add(sent);
+            }
+        }
+
+        Text.read(base + "-filt", sl, tl);
+    }
+}

--- a/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/Opus.java
+++ b/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/Opus.java
@@ -30,16 +30,12 @@ import java.util.List;
 
 public class Opus {
     public static void main(String[] args) throws Exception {
-        /*
         if(args.length != 3) {
             throw new Exception("Usage: basename source-language target-language");
         }
         String base = args[0];
         String sl = args[1];
-        String tl = args[2];*/
-        String base = "EUbookshop.en-ga";
-        String sl = "en";
-        String tl = "ga";
+        String tl = args[2];
         LanguageProperties enlp = new LanguageProperties("english", "latin");
         LanguageProperties galp = new LanguageProperties("irish", "latin");
 

--- a/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/Opus.java
+++ b/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/Opus.java
@@ -41,6 +41,7 @@ public class Opus {
 
         List<SLTLPair> orig = Text.read(base, sl, tl);
         List<SLTLPair> out = new ArrayList<SLTLPair>();
+        List<SLTLPair> del = new ArrayList<SLTLPair>();
 
         CharsetCheck ck = new CharsetCheck();
         ck.setLanguageProperties(enlp, galp);
@@ -48,9 +49,12 @@ public class Opus {
         for (SLTLPair sent : orig) {
             if(!ck.match(sent)) {
                 out.add(sent);
+            } else {
+                del.add(sent);
             }
         }
 
         Text.write(out, base + "-filt", sl, tl);
+        Text.write(del, base + "-removed", sl, tl);
     }
 }

--- a/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/RuleBase.java
+++ b/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/RuleBase.java
@@ -24,17 +24,25 @@
 
 package ie.tcd.slscs.itut.duckegg.bitext;
 
-import java.util.List;
-
-public abstract class Rule extends RuleBase {
+public abstract class RuleBase {
+    public String name;
     /**
-     * Corrects the input matched by the rule
-     * @param input The pair to be processed
-     * @return A new SLTLPair with corrections applied
+     * The name of the rule
+     * @return a string containing the name of the rule
      */
-    public abstract SLTLPair replace(SLTLPair input) throws Exception;
-    public boolean replacement = false;
-    public boolean hadReplacement() {
-        return replacement;
+    public String name() {
+        return this.name;
+    }
+
+    boolean needs_language_properties = false;
+    public boolean needsLanguageProperties() {
+        return needs_language_properties;
+    }
+    LanguageProperties srcProps;
+    LanguageProperties trgProps;
+
+    public void setLanguageProperties(LanguageProperties src, LanguageProperties trg) {
+        srcProps = src;
+        trgProps = trg;
     }
 }

--- a/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/RuleBase.java
+++ b/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/RuleBase.java
@@ -45,4 +45,9 @@ public abstract class RuleBase {
         srcProps = src;
         trgProps = trg;
     }
+
+    boolean verbose;
+    public void setVerbose(boolean verbose) {
+        this.verbose = verbose;
+    }
 }

--- a/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/SLTLPair.java
+++ b/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/SLTLPair.java
@@ -38,4 +38,14 @@ public class SLTLPair {
         this.source = source;
         this.target = target;
     }
+
+    public String getId() {
+        return id;
+    }
+    public String getSource() {
+        return source;
+    }
+    public String getTarget() {
+        return target;
+    }
 }

--- a/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/SLTLPair.java
+++ b/src/main/java/ie/tcd/slscs/itut/duckegg/bitext/SLTLPair.java
@@ -28,12 +28,12 @@ public class SLTLPair {
     String id;
     String source;
     String target;
-    SLTLPair(String id, String source, String target) {
+    public SLTLPair(String id, String source, String target) {
         this.id = id;
         this.source = source;
         this.target = target;
     }
-    SLTLPair(String source, String target) {
+    public SLTLPair(String source, String target) {
         this.id = null;
         this.source = source;
         this.target = target;

--- a/src/main/java/ie/tcd/slscs/itut/duckegg/format/opus/Text.java
+++ b/src/main/java/ie/tcd/slscs/itut/duckegg/format/opus/Text.java
@@ -1,0 +1,82 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright © 2017 Jim O'Regan
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package ie.tcd.slscs.itut.duckegg.format.opus;
+
+import ie.tcd.slscs.itut.duckegg.bitext.SLTLPair;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Text {
+    public static File tryFile(String base, String lang) throws Exception {
+        String filename = base;
+        if(filename.endsWith(".")) {
+            base += lang;
+        } else {
+            base += ".";
+            base += lang;
+        }
+        File f = new File(base + lang);
+        if(f.exists() && f.canRead()) {
+            return f;
+        } else {
+            throw new Exception("Cannot open " + filename + " for reading");
+        }
+    }
+    public static List<String> fileToStringList(File f) throws IOException {
+        List<String> out = new ArrayList<String>();
+        int lineno = 0;
+        try {
+            BufferedReader br = new BufferedReader(new FileReader(f));
+            String line;
+            while ((line = br.readLine()) != null) {
+                lineno++;
+                out.add(line);
+            }
+        } catch (IOException e) {
+            throw new IOException("Error reading file " + f.getName() + " at line " + lineno + ":" + e.getMessage());
+        }
+        return out;
+    }
+    public static List<SLTLPair> read(String base, String src, String trg) throws Exception {
+        File source = tryFile(base, src);
+        File target = tryFile(base, trg);
+        List<SLTLPair> out = new ArrayList<SLTLPair>();
+        List<String> srcTxt = fileToStringList(source);
+        List<String> trgTxt = fileToStringList(target);
+
+        if(srcTxt.size() != trgTxt.size()) {
+            throw new Exception("File mismatch: " + src + " had " + srcTxt.size() + " lines, " + trg + " had " + trgTxt.size());
+        }
+        for(int i = 0; i < srcTxt.size(); i++) {
+            out.add(new SLTLPair(srcTxt.get(i), trgTxt.get(i)));
+        }
+
+        return out;
+    }
+}

--- a/src/main/java/ie/tcd/slscs/itut/duckegg/format/opus/Text.java
+++ b/src/main/java/ie/tcd/slscs/itut/duckegg/format/opus/Text.java
@@ -25,15 +25,12 @@ package ie.tcd.slscs.itut.duckegg.format.opus;
 
 import ie.tcd.slscs.itut.duckegg.bitext.SLTLPair;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
 
 public class Text {
-    public static File tryFile(String base, String lang) throws Exception {
+    public static File tryFile(String base, String lang, boolean write) throws IOException {
         String filename = base;
         if(filename.endsWith(".")) {
             base += lang;
@@ -42,10 +39,10 @@ public class Text {
             base += lang;
         }
         File f = new File(base + lang);
-        if(f.exists() && f.canRead()) {
+        if(f.exists() && ((write && f.canWrite()) || f.canRead())) {
             return f;
         } else {
-            throw new Exception("Cannot open " + filename + " for reading");
+            throw new IOException("Cannot open " + filename + " for reading");
         }
     }
     public static List<String> fileToStringList(File f) throws IOException {
@@ -64,8 +61,8 @@ public class Text {
         return out;
     }
     public static List<SLTLPair> read(String base, String src, String trg) throws Exception {
-        File source = tryFile(base, src);
-        File target = tryFile(base, trg);
+        File source = tryFile(base, src, false);
+        File target = tryFile(base, trg, false);
         List<SLTLPair> out = new ArrayList<SLTLPair>();
         List<String> srcTxt = fileToStringList(source);
         List<String> trgTxt = fileToStringList(target);
@@ -78,5 +75,20 @@ public class Text {
         }
 
         return out;
+    }
+
+    public static void write(List<SLTLPair> sents, String base, String src, String trg) throws IOException {
+        File source = tryFile(base, src, true);
+        File target = tryFile(base, trg, true);
+        BufferedWriter srcout = new BufferedWriter(new FileWriter(source));
+        BufferedWriter trgout = new BufferedWriter(new FileWriter(target));
+        for(SLTLPair sent : sents) {
+            srcout.write(sent.getSource());
+            srcout.newLine();
+            trgout.write(sent.getTarget());
+            trgout.newLine();
+        }
+        srcout.close();
+        trgout.close();
     }
 }

--- a/src/main/java/ie/tcd/slscs/itut/duckegg/format/opus/Text.java
+++ b/src/main/java/ie/tcd/slscs/itut/duckegg/format/opus/Text.java
@@ -30,20 +30,31 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Text {
-    public static File tryFile(String base, String lang, boolean write) throws IOException {
+    public static File tryReadFile(String base, String lang) throws IOException {
         String filename = base;
         if(filename.endsWith(".")) {
-            base += lang;
+            filename += lang;
         } else {
-            base += ".";
-            base += lang;
+            filename += ".";
+            filename += lang;
         }
-        File f = new File(base + lang);
-        if(f.exists() && ((write && f.canWrite()) || f.canRead())) {
+        File f = new File(filename);
+        if(f.exists() && f.canRead()) {
             return f;
         } else {
             throw new IOException("Cannot open " + filename + " for reading");
         }
+    }
+    public static File tryWriteFile(String base, String lang) throws IOException {
+        String filename = base;
+        if(filename.endsWith(".")) {
+            filename += lang;
+        } else {
+            filename += ".";
+            filename += lang;
+        }
+        File f = new File(filename);
+        return f;
     }
     public static List<String> fileToStringList(File f) throws IOException {
         List<String> out = new ArrayList<String>();
@@ -61,8 +72,8 @@ public class Text {
         return out;
     }
     public static List<SLTLPair> read(String base, String src, String trg) throws Exception {
-        File source = tryFile(base, src, false);
-        File target = tryFile(base, trg, false);
+        File source = tryReadFile(base, src);
+        File target = tryReadFile(base, trg);
         List<SLTLPair> out = new ArrayList<SLTLPair>();
         List<String> srcTxt = fileToStringList(source);
         List<String> trgTxt = fileToStringList(target);
@@ -78,8 +89,8 @@ public class Text {
     }
 
     public static void write(List<SLTLPair> sents, String base, String src, String trg) throws IOException {
-        File source = tryFile(base, src, true);
-        File target = tryFile(base, trg, true);
+        File source = tryWriteFile(base, src);
+        File target = tryWriteFile(base, trg);
         BufferedWriter srcout = new BufferedWriter(new FileWriter(source));
         BufferedWriter trgout = new BufferedWriter(new FileWriter(target));
         for(SLTLPair sent : sents) {

--- a/src/test/java/ie/tcd/slscs/itut/duckegg/bitext/CharsetCheckTest.java
+++ b/src/test/java/ie/tcd/slscs/itut/duckegg/bitext/CharsetCheckTest.java
@@ -21,14 +21,22 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package ie.tcd.slscs.itut.duckegg.bitext;
 
-public class LanguageProperties {
-    String name;
-    String script;
-    public LanguageProperties(String name, String script) {
-        this.name = name;
-        this.script = script;
+import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class CharsetCheckTest extends TestCase {
+    public void testMatch() throws Exception {
+        LanguageProperties src = new LanguageProperties("english", "latin");
+        LanguageProperties trg = new LanguageProperties("irish", "latin");
+
+        SLTLPair chkin = new SLTLPair("A small test", "Bhí rud éigin eile ann - ελληνικά");
+        CharsetCheck chk = new CharsetCheck();
+        chk.setLanguageProperties(src, trg);
+        assertEquals(true, chk.match(chkin));
     }
+
 }


### PR DESCRIPTION
checks that, if text in a script other than those of the source and target languages appears, that the same text appears on both sides. Also, text support for OPUS-style text files. Useful for EUBookshop